### PR TITLE
Use config library to delete old device config

### DIFF
--- a/cmd/device-register/main.go
+++ b/cmd/device-register/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/TheCacophonyProject/go-api"
+	config "github.com/TheCacophonyProject/go-config"
 	"github.com/TheCacophonyProject/modemd/connrequester"
 	arg "github.com/alexflint/go-arg"
 	petname "github.com/dustinkirkland/golang-petname"
@@ -39,8 +40,6 @@ const (
 	apiURL                  = "https://api.cacophony.org.nz"
 	testAPIURL              = "https://api-test.cacophony.org.nz"
 	minionIDFile            = "/etc/salt/minion_id"
-	deviceConfigFile        = "/etc/cacophony/device.yaml"
-	devicePrivateConfigFile = "/etc/cacophony/device-priv.yaml"
 	minionIDPrefix          = "pi-"
 	minionIDTestPrefix      = "pi-test-"
 )
@@ -180,13 +179,14 @@ func writeToMinionIDFile(name string) error {
 }
 
 func deleteDeviceConfigFiles() error {
-	if err := removeFileIfExist(deviceConfigFile); err != nil {
+	conf, err := config.New(config.DefaultConfigDir)
+	if err != nil {
 		return err
 	}
-	if err := removeFileIfExist(devicePrivateConfigFile); err != nil {
+	if err := conf.Unset(config.SecretsKey); err != nil {
 		return err
 	}
-	return nil
+	return conf.Unset(config.DeviceKey)
 }
 
 func removeFileIfExist(path string) error {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/TheCacophonyProject/go-api v0.0.0-20190923033957-174cea2ac81c
+	github.com/TheCacophonyProject/go-config v1.4.0
 	github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b
 	github.com/alexflint/go-arg v1.1.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20190613200456-11339a705ed2

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/TheCacophonyProject/go-api v0.0.0-20190923033957-174cea2ac81c h1:oe4a
 github.com/TheCacophonyProject/go-api v0.0.0-20190923033957-174cea2ac81c/go.mod h1:FfMpa4cFhNXQ9tuKG18HO6yLExezcJhzjUjBOFocrQw=
 github.com/TheCacophonyProject/go-config v0.0.0-20190922224052-7c2a21bc6b88 h1:b3CpL57RUjdlgRmm54qNj37tLEwmJzNDvxOXX7GHYBw=
 github.com/TheCacophonyProject/go-config v0.0.0-20190922224052-7c2a21bc6b88/go.mod h1:gPUJLVu408NRz9/P3BrsxzOzLc+KJLrv+jVdDw3RI0Y=
+github.com/TheCacophonyProject/go-config v1.4.0 h1:G7YOqMrRljWQ0BWVHJiZNe79KaMNJMP5QyCa2fP27cs=
+github.com/TheCacophonyProject/go-config v1.4.0/go.mod h1:oARW/N3eJbcewCqB+Jc7TBwuODawwYgpo56UO6yBdKU=
 github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b h1:iJVZlC3nzjJ2EoWLBr7zKhL7t9hUleghmUIC+3ObB88=
 github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b/go.mod h1:txGgnRinv6H0/jB4n71MpuS+2qtu8tAlntIjY5udXDU=
 github.com/TheCacophonyProject/window v0.0.0-20190821235241-ab92c2ee24b6/go.mod h1:Vww417iimOb0s46Ndsm8U/vYtwc0dZUet4uW8QzBo4M=


### PR DESCRIPTION
The `--delete` option was deleting the old config file. Updated to use config library.